### PR TITLE
[kn-admin] Improve domain set command

### DIFF
--- a/plugins/admin/core/root.go
+++ b/plugins/admin/core/root.go
@@ -46,6 +46,7 @@ kn admin domain set - to set Knative route domain
 kn admin registry add - to add registry with credentials
 kn admin autoscaling update - to manage autoscaling config
 `,
+		SilenceUsage: true,
 	}
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.config/kn/plugins/admin.yaml)")

--- a/plugins/admin/pkg/command/domain/set.go
+++ b/plugins/admin/pkg/command/domain/set.go
@@ -59,7 +59,10 @@ kn admin domain set --custom-domain mydomain.com --selector app=v1
 			desiredCm := currentCm.DeepCopy()
 			labels := "selector:\n"
 			for _, label := range selector {
-				k, v, _ := splitByEqualSign(label)
+				k, v, err := splitByEqualSign(label)
+				if err != nil {
+					return err
+				}
 				label = fmt.Sprintf("  %s: %s\n", k, v)
 				labels += label
 			}
@@ -94,7 +97,7 @@ kn admin domain set --custom-domain mydomain.com --selector app=v1
 
 	domainSetCommand.Flags().StringVarP(&domain, "custom-domain", "d", "", "desired custom domain")
 	domainSetCommand.MarkFlagRequired("custom-domain")
-	domainSetCommand.Flags().StringSliceVar(&selector, "selector", nil, "domain selector")
+	domainSetCommand.Flags().StringSliceVar(&selector, "selector", nil, "domain selector. name=value; you may provide this flag any number of times to set multiple selectors.")
 	domainSetCommand.InitDefaultHelpFlag()
 
 	return domainSetCommand
@@ -103,7 +106,7 @@ kn admin domain set --custom-domain mydomain.com --selector app=v1
 func splitByEqualSign(pair string) (string, string, error) {
 	parts := strings.Split(pair, "=")
 	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
-		return "", "", fmt.Errorf("expecting the value format in value1=value2, given %s", pair)
+		return "", "", fmt.Errorf("expecting the selector format is name=vlue, but given '%s'", pair)
 	}
 	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), nil
 }


### PR DESCRIPTION
1. Improve descriptions for flag ```--selector```
2. Return error if fail to parse flag ```--selector```
3. Like ```kn``` command: https://github.com/knative/client/blob/c7426459be67bdaa95dcf2f59f4fc6fceb2ad0d5/pkg/kn/root/root.go#L62, 
Setting ```SilenceUsage: true``` for root command, so that all subcommands will not print usage with error message. 
